### PR TITLE
Add new adapter for Sublime

### DIFF
--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -6,7 +6,7 @@ const DEFAULT_BID_HOST = 'pbjs.sskzlabs.com';
 const DEFAULT_SAC_HOST = 'sac.ayads.co';
 const DEFAULT_CALLBACK_NAME = 'sublime_prebid_callback';
 const DEFAULT_PROTOCOL = 'https';
-const SUBLIME_VERSION = '0.3';
+const SUBLIME_VERSION = '0.3.1';
 let SUBLIME_ZONE = null;
 
 export const spec = {

--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -1,0 +1,142 @@
+import { registerBidder } from 'src/adapters/bidderFactory';
+import * as utils from '../src/utils';
+
+const BIDDER_CODE = 'sublime';
+const DEFAULT_BID_HOST = 'pbjs.sskzlabs.com';
+const DEFAULT_SAC_HOST = 'sac.ayads.co';
+const DEFAULT_CALLBACK_NAME = 'sublime_prebid_callback';
+const DEFAULT_PROTOCOL = 'https';
+const SUBLIME_VERSION = '0.3';
+let SUBLIME_ZONE = null;
+
+export const spec = {
+  code: BIDDER_CODE,
+  aliases: ['sskz', 'sublime-skinz'],
+
+  /**
+   * Determines whether or not the given bid request is valid.
+   *
+   * @param {BidRequest} bid The bid params to validate.
+   * @return boolean True if this is a valid bid, and false otherwise.
+   */
+  isBidRequestValid: (bid) => {
+    return !!bid.params.zoneId;
+  },
+
+  /**
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {BidRequest[]} validBidRequests An array of bids
+   * @param {Object} bidderRequest - Info describing the request to the server.
+   * @return ServerRequest Info describing the request to the server.
+   */
+  buildRequests: (validBidRequests, bidderRequest) => {
+    if (bidderRequest && bidderRequest.gdprConsent) {
+      const gdpr = {
+        consentString: bidderRequest.gdprConsent.consentString,
+        gdprApplies: (typeof bidderRequest.gdprConsent.gdprApplies === 'boolean') ? bidderRequest.gdprConsent.gdprApplies : true
+      };
+
+      window.sublime = (typeof window.sublime !== 'undefined') ? window.sublime : {};
+      window.sublime.gdpr = (typeof window.sublime.gdpr !== 'undefined') ? window.sublime.gdpr : {};
+      window.sublime.gdpr.injected = {
+        consentString: gdpr.consentString,
+        gdprApplies: gdpr.gdprApplies
+      };
+    }
+    // Grab only the first `validBidRequest`
+    let bid = validBidRequests[0];
+
+    if (validBidRequests.length > 1) {
+      let leftoverZonesIds = validBidRequests.slice(1).map(bid => { return bid.params.zoneId }).join(',');
+      utils.logWarn(`Sublime Adapter: ZoneIds ${leftoverZonesIds} are ignored. Only one ZoneId per page can be instanciated.`);
+    }
+
+    let params = bid.params;
+    let requestId = bid.bidId || '';
+    let sacHost = params.sacHost || DEFAULT_SAC_HOST;
+    let bidHost = params.bidHost || DEFAULT_BID_HOST;
+    let protocol = params.protocol || DEFAULT_PROTOCOL;
+    let callbackName = (params.callbackName || DEFAULT_CALLBACK_NAME) + '_' + params.zoneId;
+    SUBLIME_ZONE = params.zoneId;
+
+    window[callbackName] = (response) => {
+      var requestIdEncoded = encodeURIComponent(requestId);
+      var hasAd = response.ad ? '1' : '0';
+      var xhr = new XMLHttpRequest();
+      var url = protocol + '://' + bidHost + '/notify?request_id=' + requestIdEncoded + '&a=' + hasAd + '&z=' + SUBLIME_ZONE;
+      xhr.open('POST', url, true);
+      xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+      xhr.send(
+        'notify=1' +
+        '&request_id=' + requestIdEncoded +
+        '&ad=' + encodeURIComponent(response.ad || '') +
+        '&cpm=' + encodeURIComponent(response.cpm || 0) +
+        '&currency=' + encodeURIComponent(response.currency || 'USD') +
+        '&v=' + SUBLIME_VERSION
+      );
+      return xhr;
+    };
+    let script = document.createElement('script');
+    script.type = 'application/javascript';
+    script.src = 'https://' + sacHost + '/sublime/' + SUBLIME_ZONE + '/prebid?callback=' + callbackName;
+    document.body.appendChild(script);
+
+    return {
+      method: 'GET',
+      url: protocol + '://' + bidHost + '/bid',
+      data: {
+        prebid: 1,
+        request_id: requestId,
+        z: SUBLIME_ZONE
+      }
+    };
+  },
+
+  /**
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {*} serverResponse A successful response from the server.
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   */
+  interpretResponse: (serverResponse) => {
+    const bidResponses = [];
+    const response = serverResponse.body;
+
+    if (response) {
+      const regexNoAd = /no ad/gmi;
+      const bidResponse = {
+        requestId: serverResponse.body.request_id || '',
+        cpm: serverResponse.body.cpm || 0,
+        width: 1800,
+        height: 1000,
+        creativeId: 1,
+        dealId: 1,
+        currency: serverResponse.body.currency || 'USD',
+        netRevenue: true,
+        ttl: 600,
+        referrer: '',
+        ad: serverResponse.body.ad || '',
+      };
+
+      if (!response.timeout && !bidResponse.ad.match(regexNoAd) && response.cpm) {
+        bidResponses.push(bidResponse);
+      }
+    }
+
+    return bidResponses;
+  },
+
+  /**
+   * User syncs.
+   *
+   * @param {*} syncOptions Publisher prebid configuration.
+   * @param {*} serverResponses A successful response from the server.
+   * @return {Syncs[]} An array of syncs that should be executed.
+   */
+  getUserSyncs: (syncOptions, serverResponses) => {
+    return [];
+  }
+};
+
+registerBidder(spec);

--- a/modules/sublimeBidAdapter.md
+++ b/modules/sublimeBidAdapter.md
@@ -1,0 +1,54 @@
+# Overview
+
+```
+Module Name:  Sublime Bid Adapter
+Module Type:  Bidder Adapter
+Maintainer: pbjs@sublimeskinz.com
+```
+
+# Description
+
+Connects to Sublime for bids.
+Sublime bid adapter supports Skinz and M-Skinz formats.
+
+# Build
+
+You can build your version of prebid.js, execute: 
+
+```shell
+gulp build --modules=sublimeBidAdapter
+```
+
+Or to build with multiple adapters
+
+```shell
+gulp build --modules=sublimeBidAdapter,secondAdapter,thirdAdapter
+```
+
+More details in the root [README](../README.md#Build)
+
+## To build from you own repository
+
+- copy `/modules/sublimeBidAdapter.js` to your `/modules/` directory
+- copy `/modules/sublimeBidAdapter.md` to your `/modules/` directory
+- copy `/test/spec/modules/sublimeBidAdapter_spec.js` to your `/test/spec/modules/` directory
+
+Then build
+
+
+# Invocation Parameters
+
+```js
+var adUnits = [{
+    code: 'sublime',
+    sizes: [[1800, 1000]],
+    bids: [{
+        bidder: 'sublime',
+        params: {
+            zoneId: <zoneId>
+        }
+    }]
+}];
+```
+
+Where you replace `<zoneId>` by your Sublime Zone id

--- a/test/spec/modules/sublimeBidAdapter_spec.js
+++ b/test/spec/modules/sublimeBidAdapter_spec.js
@@ -1,0 +1,207 @@
+import { expect } from 'chai';
+import { spec } from 'modules/sublimeBidAdapter';
+import { newBidder } from 'src/adapters/bidderFactory';
+
+describe('Sublime Adapter', () => {
+  const adapter = newBidder(spec);
+
+  describe('inherited functions', () => {
+    it('exists and is a function', () => {
+      expect(adapter.callBids).to.exist.and.to.be.a('function');
+    });
+  });
+
+  describe('isBidRequestValid', () => {
+    let bid = {
+      bidder: 'sublime',
+      params: {
+        zoneId: 24549,
+        endpoint: '',
+        sacHost: 'sac.ayads.co',
+      },
+    };
+
+    it('should return true when required params found', () => {
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+
+    it('should return false when required params are not passed', () => {
+      let bid = Object.assign({}, bid);
+      bid.params = {};
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+  });
+
+  describe('buildRequests', () => {
+    let bidRequests = [
+      {
+        bidder: 'sublime',
+        adUnitCode: 'sublime_code',
+        bidId: 'abc1234',
+        sizes: [[1800, 1000], [640, 300]],
+        requestId: 'xyz654',
+        params: {
+          zoneId: 14312,
+          bidHost: 'pbjs.ayads.co.local',
+          callbackName: 'myCallback'
+        }
+      }, {
+        bidder: 'sublime',
+        adUnitCode: 'sublime_code_2',
+        bidId: 'abc1234_2',
+        sizes: [[1800, 1000], [640, 300]],
+        requestId: 'xyz654_2',
+        params: {
+          zoneId: 14313,
+          bidHost: 'pbjs.ayads.co.local',
+          callbackName: 'myCallback'
+        }
+      }
+    ];
+
+    let bidderRequest = {
+      gdprConsent: {
+        consentString: 'EOHEIRCOUCOUIEHZIOEIU-TEST',
+        gdprApplies: true
+      }
+    };
+
+    let request = spec.buildRequests(bidRequests, bidderRequest);
+
+    it('should have a get method', () => {
+      expect(request.method).to.equal('GET');
+    });
+
+    it('should contains window.sublime.gdpr.injected', () => {
+      expect(window.sublime).to.not.be.undefined;
+      expect(window.sublime.gdpr).to.not.be.undefined;
+      expect(window.sublime.gdpr.injected).to.eql({
+        consentString: bidderRequest.gdprConsent.consentString,
+        gdprApplies: bidderRequest.gdprConsent.gdprApplies
+      });
+    });
+
+    it('should contains a request id equals to the bid id', () => {
+      expect(request.data.request_id).to.equal(bidRequests[0].bidId);
+    });
+
+    it('should have an url that contains bid keyword', () => {
+      expect(request.url).to.match(/bid/);
+    });
+
+    it('should create a callback function', () => {
+      const params = bidRequests[0].params;
+      expect(window[params.callbackName + '_' + params.zoneId]).to.be.an('function');
+    });
+  });
+
+  describe('buildRequests: default arguments', () => {
+    let bidRequests = [{
+      bidder: 'sublime',
+      adUnitCode: 'sublime_code',
+      bidId: 'abc1234',
+      sizes: [[1800, 1000], [640, 300]],
+      requestId: 'xyz654',
+      params: {
+        zoneId: 1
+      }
+    }];
+
+    let request = spec.buildRequests(bidRequests);
+
+    it('should have an url that match the default endpoint', () => {
+      expect(request.url).to.equal('https://pbjs.sskzlabs.com/bid');
+    });
+
+    it('should create a default callback function', () => {
+      expect(window['sublime_prebid_callback_1']).to.be.an('function');
+    });
+  });
+
+  describe('buildRequests: test callback', () => {
+    let XMLHttpRequest = sinon.useFakeXMLHttpRequest();
+
+    let bidRequests = [{
+      bidder: 'sublime',
+      adUnitCode: 'sublime_code',
+      bidId: 'abc1234',
+      sizes: [[1800, 1000], [640, 300]],
+      requestId: 'xyz654',
+      params: {
+        zoneId: 1
+      }
+    }];
+
+    spec.buildRequests(bidRequests);
+
+    it('should execute a default callback function', () => {
+      let response = {
+        ad: '<h1>oh</h1>',
+        cpm: 2
+      };
+      let actual = window['sublime_prebid_callback_1'](response);
+
+      it('should query the notify url', () => {
+        expect(actual.url).to.equal('https://pbjs.ayads.co/notify');
+      });
+
+      it('should send the correct headers', () => {
+        expect(actual.requestHeaders).to.equal({
+          'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8'
+        });
+      });
+
+      it('should send the correct body', () => {
+        expect(actual.requestBody).to.equal('notify=1&request_id=abc1234&ad=%3Ch1%3Eoh%3C%2Fh1%3E&cpm=2');
+      });
+    });
+  });
+
+  describe('interpretResponse', () => {
+    let serverResponse = {
+      'request_id': '3db3773286ee59',
+      'cpm': 0.5,
+      'ad': '<!-- Creative -->',
+    };
+
+    it('should get correct bid response', () => {
+      // Mock the fire method
+      top.window.sublime = {
+        analytics: {
+          fire: function() {}
+        }
+      };
+
+      let expectedResponse = [
+        {
+          requestId: '',
+          cpm: 0.5,
+          width: 1800,
+          height: 1000,
+          creativeId: 1,
+          dealId: 1,
+          currency: 'USD',
+          netRevenue: true,
+          ttl: 600,
+          referrer: '',
+          ad: '',
+        },
+      ];
+      let result = spec.interpretResponse({body: serverResponse});
+      expect(Object.keys(result[0])).to.have.members(Object.keys(expectedResponse[0]));
+    });
+
+    it('should get empty bid responses', () => {
+      let serverResponse = {};
+      let result = spec.interpretResponse({body: serverResponse});
+      expect(result).to.deep.equal([]);
+    });
+  });
+
+  describe('getUserSyncs', () => {
+    it('should return an empty array', () => {
+      let syncs = spec.getUserSyncs();
+      expect(syncs).to.be.an('array').that.is.empty;
+    });
+  });
+});


### PR DESCRIPTION
## Type of change
- [x] New bidder adapter

## Description of change
Added new Adapter for [Sublime](https://sublime.xyz/en)

- code: modules/sublimeBidAdapter.js
- doc: modules/sublimeBidAdapter.md
- unit test: test/spec/modules/sublimeBidAdapter_spec.js

- test parameters for validating bids
```
{
  bidder: 'sublime',
  params: {
    zoneId: 16007
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [x] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
