### PR TITLE
Sublime adapter debug

### DIFF
--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -1,0 +1,102 @@
+import { registerBidder } from 'src/adapters/bidderFactory';
+
+const BIDDER_CODE = 'sublime';
+const DEFAULT_BID_HOST = 'pbjs.ayads.co';
+const DEFAULT_SAC_HOST = 'sac.ayads.co';
+const DEFAULT_CALLBACK_NAME = 'sublime_prebid_callback';
+
+export const spec = {
+  code: BIDDER_CODE,
+  aliases: ['sskz', 'sublime-skinz'],
+
+  /**
+   * Determines whether or not the given bid request is valid.
+   *
+   * @param {BidRequest} bid The bid params to validate.
+   * @return boolean True if this is a valid bid, and false otherwise.
+   */
+  isBidRequestValid: (bid) => {
+    return !!bid.params.zoneId;
+  },
+
+  /**
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {BidRequest[]} validBidRequests An array of bids
+   * @return ServerRequest Info describing the request to the server.
+   */
+  buildRequests: (validBidRequests) => {
+    let params = validBidRequests[0].params;
+    let requestId = validBidRequests[0].bidId || '';
+    let sacHost = params.sacHost || DEFAULT_SAC_HOST;
+    let bidHost = params.bidHost || DEFAULT_BID_HOST;
+    let zoneId = params.zoneId;
+    let callbackName = params.callbackName || DEFAULT_CALLBACK_NAME;
+
+    window[callbackName] = (response) => {
+      var xhr = new XMLHttpRequest();
+      var url = 'https://' + bidHost + '/notify';
+      xhr.open('POST', url, true);
+      xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+      xhr.send(
+        'notify=1' +
+        '&request_id=' + encodeURIComponent(requestId) +
+        '&ad=' + encodeURIComponent(response.ad || '') +
+        '&cpm=' + encodeURIComponent(response.cpm || 0)
+      );
+    };
+    let script = document.createElement('script');
+    script.type = 'application/javascript';
+    script.src = 'https://' + sacHost + '/sublime/' + zoneId + '/prebid?callback=' + callbackName;
+    document.body.appendChild(script);
+
+    return {
+      method: 'GET',
+      url: 'https://' + bidHost + '/bid',
+      data: {
+        prebid: 1,
+        request_id: requestId,
+      }
+    };
+  },
+
+  /**
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {*} serverResponse A successful response from the server.
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   */
+  interpretResponse: (serverResponse) => {
+    const bidResponses = [];
+    const bidResponse = {
+      requestId: serverResponse.body.request_id || '',
+      cpm: serverResponse.body.cpm || 0,
+      width: 1800,
+      height: 1000,
+      creativeId: 1,
+      dealId: 1,
+      currency: serverResponse.body.currency || 'USD',
+      netRevenue: true,
+      ttl: 600,
+      referrer: '',
+      ad: serverResponse.body.ad || '',
+    };
+    if (bidResponse.cpm) {
+      bidResponses.push(bidResponse);
+    }
+    return bidResponses;
+  },
+
+  /**
+   * User syncs.
+   *
+   * @param {*} syncOptions Publisher prebid configuration.
+   * @param {*} serverResponses A successful response from the server.
+   * @return {Syncs[]} An array of syncs that should be executed.
+   */
+  getUserSyncs: (syncOptions, serverResponses) => {
+    return [];
+  }
+}
+
+registerBidder(spec);

--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -44,8 +44,10 @@ export const spec = {
     // Grab only the first `validBidRequest`
     let bid = validBidRequests[0];
 
-    let leftoverZonesIds = validBidRequests.slice(1).map(bid => { return bid.params.zoneId }).join(',');
-    utils.logWarn(`Sublime Adapter: ZoneIds ${leftoverZonesIds} are ignored. Only one ZoneId per page can be instanciated.`);
+    if (validBidRequests.length > 1) {
+      let leftoverZonesIds = validBidRequests.slice(1).map(bid => { return bid.params.zoneId }).join(',');
+      utils.logWarn(`Sublime Adapter: ZoneIds ${leftoverZonesIds} are ignored. Only one ZoneId per page can be instanciated.`);
+    }
 
     let params = bid.params;
     let requestId = bid.bidId || '';

--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -156,12 +156,12 @@ export const spec = {
         });
       }
     } else {
-        // debug pixel no request
-        top.sublime.analytics.fire('dirnorq', {
-          qs: {
-            z: SUBLIME_ZONE
-          }
-        });
+      // debug pixel no request
+      top.sublime.analytics.fire('dirnorq', {
+        qs: {
+          z: SUBLIME_ZONE
+        }
+      });
     }
 
     return bidResponses;
@@ -176,6 +176,17 @@ export const spec = {
    */
   getUserSyncs: (syncOptions, serverResponses) => {
     return [];
+  },
+
+  /**
+   * @param {TimedOutBid} timeoutData
+   */
+  onTimeout: (timeoutData) => {
+    // debug pixel timeout from pbjs
+    var ts = new Date().getTime();
+    var url = 'https://antenna.ayads.co/?t=' + ts + '&z=' + timeoutData.params[0].zoneId + '&e=dbidtimeout';
+
+    utils.triggerPixel(url);
   }
 };
 

--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -44,6 +44,7 @@ export const spec = {
         '&ad=' + encodeURIComponent(response.ad || '') +
         '&cpm=' + encodeURIComponent(response.cpm || 0)
       );
+      return xhr;
     };
     let script = document.createElement('script');
     script.type = 'application/javascript';

--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -58,7 +58,8 @@ export const spec = {
           'notify=1' +
           '&request_id=' + encodeURIComponent(requestId) +
           '&ad=' + encodeURIComponent(response.ad || '') +
-          '&cpm=' + encodeURIComponent(response.cpm || 0)
+          '&cpm=' + encodeURIComponent(response.cpm || 0) +
+          '&currency=' + encodeURIComponent(response.currency ||'USD')
         );
         return xhr;
       };

--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -64,7 +64,7 @@ export const spec = {
       var requestIdEncoded = encodeURIComponent(requestId);
       var hasAd = response.ad ? '1' : '0';
       var xhr = new XMLHttpRequest();
-      var url = protocol + '://' + bidHost + '/notify?request_id=' + requestIdEncoded + '&a=' + hasAd;
+      var url = protocol + '://' + bidHost + '/notify?request_id=' + requestIdEncoded + '&a=' + hasAd + '&z=' + SUBLIME_ZONE;
       xhr.open('POST', url, true);
       xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
       xhr.send(
@@ -88,6 +88,7 @@ export const spec = {
       data: {
         prebid: 1,
         request_id: requestId,
+        z: SUBLIME_ZONE
       }
     };
   },

--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -4,6 +4,7 @@ const BIDDER_CODE = 'sublime';
 const DEFAULT_BID_HOST = 'pbjs.ayads.co';
 const DEFAULT_SAC_HOST = 'sac.ayads.co';
 const DEFAULT_CALLBACK_NAME = 'sublime_prebid_callback';
+const DEFAULT_PROTOCOL = 'https';
 
 export const spec = {
   code: BIDDER_CODE,
@@ -34,12 +35,13 @@ export const spec = {
     let requestId = validBidRequests[0].bidId || '';
     let sacHost = params.sacHost || DEFAULT_SAC_HOST;
     let bidHost = params.bidHost || DEFAULT_BID_HOST;
+    let protocol = params.protocol || DEFAULT_PROTOCOL;
     let zoneId = params.zoneId;
     let callbackName = params.callbackName || DEFAULT_CALLBACK_NAME;
 
     window[callbackName] = (response) => {
       var xhr = new XMLHttpRequest();
-      var url = 'https://' + bidHost + '/notify';
+      var url = protocol + '://' + bidHost + '/notify';
       xhr.open('POST', url, true);
       xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
       xhr.send(
@@ -57,7 +59,7 @@ export const spec = {
 
     return {
       method: 'GET',
-      url: 'https://' + bidHost + '/bid',
+      url: protocol + '://' + bidHost + '/bid',
       data: {
         prebid: 1,
         request_id: requestId,

--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -6,7 +6,7 @@ const DEFAULT_BID_HOST = 'pbjs.ayads.co';
 const DEFAULT_SAC_HOST = 'sac.ayads.co';
 const DEFAULT_CALLBACK_NAME = 'sublime_prebid_callback';
 const DEFAULT_PROTOCOL = 'https';
-const SUBLIME_VERSION = '0.1';
+const SUBLIME_VERSION = '0.2';
 let SUBLIME_ZONE = null;
 
 /**
@@ -21,9 +21,12 @@ function sendAntennaPixel(name) {
       }
     });
   } else {
+    var et = Math.round(sublime.window.performance.now());
     var ts = new Date().getTime();
-    var url = 'https://antenna.ayads.co/?t=' + ts + '&z=' + SUBLIME_ZONE + '&e=' + name;
-
+    var url = 'https://antenna.ayads.co/?t=' + ts + '&z=' + SUBLIME_ZONE + '&e=' + name + '&et=' + et;
+    if (requestId) {
+      url += '&uuid2' + encodeURIComponent(requestId);
+    }
     utils.triggerPixel(url);
   }
 }

--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -61,6 +61,12 @@ export const spec = {
     SUBLIME_ZONE = params.zoneId;
 
     window[callbackName] = (response) => {
+      top.sublime.analytics.fire('dpnlp', {
+        qs: {
+          z: SUBLIME_ZONE
+        }
+      });
+
       var requestIdEncoded = encodeURIComponent(requestId);
       var hasAd = response.ad ? '1' : '0';
       var xhr = new XMLHttpRequest();

--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -59,7 +59,7 @@ export const spec = {
           '&request_id=' + encodeURIComponent(requestId) +
           '&ad=' + encodeURIComponent(response.ad || '') +
           '&cpm=' + encodeURIComponent(response.cpm || 0) +
-          '&currency=' + encodeURIComponent(response.currency ||'USD')
+          '&currency=' + encodeURIComponent(response.currency || 'USD')
         );
         return xhr;
       };

--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -26,7 +26,20 @@ export const spec = {
    * @param {BidRequest[]} validBidRequests An array of bids
    * @return ServerRequest Info describing the request to the server.
    */
-  buildRequests: (validBidRequests) => {
+  buildRequests: (validBidRequests, bidderRequest) => {
+    if (bidderRequest && bidderRequest.gdprConsent) {
+      const gdpr = {
+        consentString: bidderRequest.gdprConsent.consentString,
+        gdprApplies: (typeof bidderRequest.gdprConsent.gdprApplies === 'boolean') ? bidderRequest.gdprConsent.gdprApplies : true
+      };
+
+      window.sublime = (typeof window.sublime !== 'undefined') ? window.sublime : {};
+      window.sublime.gdpr = (typeof window.sublime.gdpr !== 'undefined') ? window.sublime.gdpr : {};
+      window.sublime.gdpr.injected = {
+        consentString: gdpr.consentString,
+        gdprApplies: gdpr.gdprApplies
+      };
+    }
     return validBidRequests.map(bid => {
       let params = bid.params;
       let requestId = bid.bidId || '';

--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -27,6 +27,7 @@ export const spec = {
    * Make a server request from the list of BidRequests.
    *
    * @param {BidRequest[]} validBidRequests An array of bids
+   * @param {Object} bidderRequest - Info describing the request to the server.
    * @return ServerRequest Info describing the request to the server.
    */
   buildRequests: (validBidRequests, bidderRequest) => {
@@ -71,7 +72,8 @@ export const spec = {
         '&request_id=' + requestIdEncoded +
         '&ad=' + encodeURIComponent(response.ad || '') +
         '&cpm=' + encodeURIComponent(response.cpm || 0) +
-        '&currency=' + encodeURIComponent(response.currency || 'USD')
+        '&currency=' + encodeURIComponent(response.currency || 'USD') +
+        '&v=' + SUBLIME_VERSION
       );
       return xhr;
     };
@@ -136,6 +138,6 @@ export const spec = {
   getUserSyncs: (syncOptions, serverResponses) => {
     return [];
   }
-}
+};
 
 registerBidder(spec);

--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -6,7 +6,7 @@ const DEFAULT_BID_HOST = 'pbjs.ayads.co';
 const DEFAULT_SAC_HOST = 'sac.ayads.co';
 const DEFAULT_CALLBACK_NAME = 'sublime_prebid_callback';
 const DEFAULT_PROTOCOL = 'https';
-const SUBLIME_VERSION = '0.3';
+const SUBLIME_VERSION = '0.3.1';
 let SUBLIME_ZONE = null;
 
 /**
@@ -15,7 +15,7 @@ let SUBLIME_ZONE = null;
  * @param {String} [requestId]
  */
 function sendAntennaPixel(name, requestId) {
-  if (typeof top.sublime !== 'undefined') {
+  if (typeof top.sublime !== 'undefined' && typeof top.sublime.analytics !== 'undefined') {
     let param = {
       qs: {
         z: SUBLIME_ZONE

--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -7,6 +7,7 @@ const DEFAULT_SAC_HOST = 'sac.ayads.co';
 const DEFAULT_CALLBACK_NAME = 'sublime_prebid_callback';
 const DEFAULT_PROTOCOL = 'https';
 const SUBLIME_VERSION = '0.1';
+let SUBLIME_ZONE = null;
 
 export const spec = {
   code: BIDDER_CODE,
@@ -55,8 +56,8 @@ export const spec = {
     let sacHost = params.sacHost || DEFAULT_SAC_HOST;
     let bidHost = params.bidHost || DEFAULT_BID_HOST;
     let protocol = params.protocol || DEFAULT_PROTOCOL;
-    let zoneId = params.zoneId;
     let callbackName = (params.callbackName || DEFAULT_CALLBACK_NAME) + '_' + params.zoneId;
+    SUBLIME_ZONE = params.zoneId;
 
     window[callbackName] = (response) => {
       var requestIdEncoded = encodeURIComponent(requestId);
@@ -76,7 +77,7 @@ export const spec = {
     };
     let script = document.createElement('script');
     script.type = 'application/javascript';
-    script.src = 'https://' + sacHost + '/sublime/' + zoneId + '/prebid?callback=' + callbackName;
+    script.src = 'https://' + sacHost + '/sublime/' + SUBLIME_ZONE + '/prebid?callback=' + callbackName;
     document.body.appendChild(script);
 
     return {
@@ -115,6 +116,11 @@ export const spec = {
       };
       if (bidResponse.cpm) {
         bidResponses.push(bidResponse);
+        top.sublime.analytics.fire('bid', {
+          qs: {
+            z: SUBLIME_ZONE
+          }
+        });
       }
     }
     return bidResponses;

--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -60,8 +60,18 @@ export const spec = {
     let callbackName = (params.callbackName || DEFAULT_CALLBACK_NAME) + '_' + params.zoneId;
     SUBLIME_ZONE = params.zoneId;
 
+    // debug pixel if window[callbackName] already exists
+    if (typeof window[callbackName] === "function") {
+      if (typeof top.sublime !== "undefined") {
+        top.sublime.analytics.fire('dpbcalae', {
+          qs: {
+            z: SUBLIME_ZONE
+          }
+        });
+      }
+    }
     window[callbackName] = (response) => {
-      top.sublime.analytics.fire('dpnlp', {
+      top.sublime.analytics.fire('dpubclbcal', {
         qs: {
           z: SUBLIME_ZONE
         }
@@ -106,6 +116,13 @@ export const spec = {
    * @return {Bid[]} An array of bids which were nested inside the server.
    */
   interpretResponse: (serverResponse) => {
+    // debug pixel interpret response
+    top.sublime.analytics.fire('dintres', {
+      qs: {
+        z: SUBLIME_ZONE
+      }
+    });
+
     const bidResponses = [];
     const request = serverResponse.body;
 
@@ -130,8 +147,23 @@ export const spec = {
             z: SUBLIME_ZONE
           }
         });
+      } else {
+        // debug pixel no cpm
+        top.sublime.analytics.fire('dirnocpm', {
+          qs: {
+            z: SUBLIME_ZONE
+          }
+        });
       }
+    } else {
+        // debug pixel no request
+        top.sublime.analytics.fire('dirnorq', {
+          qs: {
+            z: SUBLIME_ZONE
+          }
+        });
     }
+
     return bidResponses;
   },
 

--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -16,6 +16,10 @@ export const spec = {
    * @return boolean True if this is a valid bid, and false otherwise.
    */
   isBidRequestValid: (bid) => {
+    if (typeof window.sublime !== 'undefined' && window.sublime.env('mode') === 'pb') {
+      return false;
+    }
+
     return !!bid.params.zoneId;
   },
 

--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -6,6 +6,7 @@ const DEFAULT_BID_HOST = 'pbjs.ayads.co';
 const DEFAULT_SAC_HOST = 'sac.ayads.co';
 const DEFAULT_CALLBACK_NAME = 'sublime_prebid_callback';
 const DEFAULT_PROTOCOL = 'https';
+const SUBLIME_VERSION = '0.1';
 
 export const spec = {
   code: BIDDER_CODE,
@@ -58,13 +59,15 @@ export const spec = {
     let callbackName = (params.callbackName || DEFAULT_CALLBACK_NAME) + '_' + params.zoneId;
 
     window[callbackName] = (response) => {
+      var requestIdEncoded = encodeURIComponent(requestId);
+      var hasAd = response.ad ? '1' : '0';
       var xhr = new XMLHttpRequest();
-      var url = protocol + '://' + bidHost + '/notify';
+      var url = protocol + '://' + bidHost + '/notify?request_id=' + requestIdEncoded + '&a=' + hasAd;
       xhr.open('POST', url, true);
       xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
       xhr.send(
         'notify=1' +
-        '&request_id=' + encodeURIComponent(requestId) +
+        '&request_id=' + requestIdEncoded +
         '&ad=' + encodeURIComponent(response.ad || '') +
         '&cpm=' + encodeURIComponent(response.cpm || 0) +
         '&currency=' + encodeURIComponent(response.currency || 'USD')

--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -2,7 +2,7 @@ import { registerBidder } from 'src/adapters/bidderFactory';
 import * as utils from '../src/utils';
 
 const BIDDER_CODE = 'sublime';
-const DEFAULT_BID_HOST = 'pbjs.ayads.co';
+const DEFAULT_BID_HOST = 'pbjs.sskzlabs.com';
 const DEFAULT_SAC_HOST = 'sac.ayads.co';
 const DEFAULT_CALLBACK_NAME = 'sublime_prebid_callback';
 const DEFAULT_PROTOCOL = 'https';

--- a/modules/sublimeBidAdapter.md
+++ b/modules/sublimeBidAdapter.md
@@ -11,17 +11,44 @@ Maintainer: pbjs@sublimeskinz.com
 Connects to Sublime for bids.
 Sublime bid adapter supports Skinz and M-Skinz formats.
 
-# Test Parameters
+# Build
 
+You can build your version of prebid.js, execute: 
+
+```shell
+gulp build --modules=sublimeBidAdapter
 ```
+
+Or to build with multiple adapters
+
+```shell
+gulp build --modules=sublimeBidAdapter,secondAdapter,thirdAdapter
+```
+
+More details in the root [README](../README.md#Build)
+
+## To build from you own repository
+
+- copy `/modules/sublimeBidAdapter.js` to your `/modules/` directory
+- copy `/modules/sublimeBidAdapter.md` to your `/modules/` directory
+- copy `/test/spec/modules/sublimeBidAdapter_spec.js` to your `/test/spec/modules/` directory
+
+Then build
+
+
+# Invocation Parameters
+
+```js
 var adUnits = [{
     code: 'sublime',
     sizes: [[1800, 1000]],
     bids: [{
         bidder: 'sublime',
         params: {
-            zoneId: 1
+            zoneId: <zoneId>
         }
     }]
 }];
 ```
+
+Where you replace `<zoneId>` by your Sublime Zone id

--- a/modules/sublimeBidAdapter.md
+++ b/modules/sublimeBidAdapter.md
@@ -1,0 +1,27 @@
+# Overview
+
+```
+Module Name:  Sublime Bid Adapter
+Module Type:  Bidder Adapter
+Maintainer: pbjs@sublimeskinz.com
+```
+
+# Description
+
+Connects to Sublime for bids.
+Sublime bid adapter supports Skinz and M-Skinz formats.
+
+# Test Parameters
+
+```
+var adUnits = [{
+    code: 'sublime',
+    sizes: [[1800, 1000]],
+    bids: [{
+        bidder: 'sublime',
+        params: {
+            zoneId: 1
+        }
+    }]
+}];
+```

--- a/test/spec/modules/sublimeBidAdapter_spec.js
+++ b/test/spec/modules/sublimeBidAdapter_spec.js
@@ -79,14 +79,6 @@ describe('Sublime Adapter', () => {
 
     let request = spec.buildRequests(bidRequests);
 
-    it('should have a get method', () => {
-      expect(request.method).to.equal('GET');
-    });
-
-    it('should contains a request id equals to the bid id', () => {
-      expect(request.data.request_id).to.equal(bidRequests[0].bidId);
-    });
-
     it('should have an url that match the default endpoint', () => {
       expect(request.url).to.equal('https://pbjs.ayads.co/bid');
     });

--- a/test/spec/modules/sublimeBidAdapter_spec.js
+++ b/test/spec/modules/sublimeBidAdapter_spec.js
@@ -30,6 +30,15 @@ describe('Sublime Adapter', () => {
       bid.params = {};
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
+
+    it('should return false if sublime already exists and is in prebid mode', () => {
+      window.sublime = {env: function() { }};
+      sinon.stub(window.sublime, 'env').returns('pb');
+
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+
+      delete window.sublime;
+    });
   });
 
   describe('buildRequests', () => {

--- a/test/spec/modules/sublimeBidAdapter_spec.js
+++ b/test/spec/modules/sublimeBidAdapter_spec.js
@@ -165,6 +165,13 @@ describe('Sublime Adapter', () => {
     };
 
     it('should get correct bid response', () => {
+      // Mock the fire method
+      top.window.sublime = {
+        analytics: {
+          fire: function() {}
+        }
+      };
+
       let expectedResponse = [
         {
           requestId: '',

--- a/test/spec/modules/sublimeBidAdapter_spec.js
+++ b/test/spec/modules/sublimeBidAdapter_spec.js
@@ -66,12 +66,10 @@ describe('Sublime Adapter', () => {
       }
     };
 
-    let requests = spec.buildRequests(bidRequests, bidderRequest);
+    let request = spec.buildRequests(bidRequests, bidderRequest);
 
     it('should have a get method', () => {
-      requests.map(request => {
-        expect(request.method).to.equal('GET');
-      });
+      expect(request.method).to.equal('GET');
     });
 
     it('should contains window.sublime.gdpr.injected', () => {
@@ -84,22 +82,16 @@ describe('Sublime Adapter', () => {
     });
 
     it('should contains a request id equals to the bid id', () => {
-      requests.map((request, index) => {
-        expect(request.data.request_id).to.equal(bidRequests[index].bidId);
-      });
+      expect(request.data.request_id).to.equal(bidRequests[0].bidId);
     });
 
     it('should have an url that contains bid keyword', () => {
-      requests.map(request => {
-        expect(request.url).to.match(/bid/);
-      });
+      expect(request.url).to.match(/bid/);
     });
 
     it('should create a callback function', () => {
-      requests.map((request, index) => {
-        const params = bidRequests[index].params;
-        expect(window[params.callbackName + '_' + params.zoneId]).to.be.an('function');
-      });
+      const params = bidRequests[0].params;
+      expect(window[params.callbackName + '_' + params.zoneId]).to.be.an('function');
     });
   });
 
@@ -115,12 +107,10 @@ describe('Sublime Adapter', () => {
       }
     }];
 
-    let requests = spec.buildRequests(bidRequests);
+    let request = spec.buildRequests(bidRequests);
 
     it('should have an url that match the default endpoint', () => {
-      requests.map(request => {
-        expect(request.url).to.equal('https://pbjs.ayads.co/bid');
-      });
+      expect(request.url).to.equal('https://pbjs.ayads.co/bid');
     });
 
     it('should create a default callback function', () => {

--- a/test/spec/modules/sublimeBidAdapter_spec.js
+++ b/test/spec/modules/sublimeBidAdapter_spec.js
@@ -59,11 +59,27 @@ describe('Sublime Adapter', () => {
       }
     ];
 
-    let requests = spec.buildRequests(bidRequests);
+    let bidderRequest = {
+      gdprConsent: {
+        consentString: 'EOHEIRCOUCOUIEHZIOEIU-TEST',
+        gdprApplies: true
+      }
+    };
+
+    let requests = spec.buildRequests(bidRequests, bidderRequest);
 
     it('should have a get method', () => {
       requests.map(request => {
         expect(request.method).to.equal('GET');
+      });
+    });
+
+    it('should contains window.sublime.gdpr.injected', () => {
+      expect(window.sublime).to.not.be.undefined;
+      expect(window.sublime.gdpr).to.not.be.undefined;
+      expect(window.sublime.gdpr.injected).to.eql({
+        consentString: bidderRequest.gdprConsent.consentString,
+        gdprApplies: bidderRequest.gdprConsent.gdprApplies
       });
     });
 

--- a/test/spec/modules/sublimeBidAdapter_spec.js
+++ b/test/spec/modules/sublimeBidAdapter_spec.js
@@ -1,0 +1,106 @@
+import { expect } from 'chai';
+import { spec } from 'modules/sublimeBidAdapter';
+import { newBidder } from 'src/adapters/bidderFactory';
+
+describe('Sublime Adapter', () => {
+  const adapter = newBidder(spec);
+
+  describe('inherited functions', () => {
+    it('exists and is a function', () => {
+      expect(adapter.callBids).to.exist.and.to.be.a('function');
+    });
+  });
+
+  describe('isBidRequestValid', () => {
+    let bid = {
+      bidder: 'sublime',
+      params: {
+        zoneId: 24549,
+        endpoint: '',
+        sacHost: 'sac.ayads.co',
+      },
+    };
+
+    it('should return true when required params found', () => {
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+
+    it('should return false when required params are not passed', () => {
+      let bid = Object.assign({}, bid);
+      bid.params = {};
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+  });
+
+  describe('buildRequests', () => {
+    let bidRequests = [{
+      bidder: 'sublime',
+      adUnitCode: 'sublime_code',
+      bidId: 'abc1234',
+      sizes: [[1800, 1000], [640, 300]],
+      requestId: 'xyz654',
+      params: {
+        zoneId: 14312,
+        bidHost: 'pbjs.ayads.co.local',
+        callbackName: 'myCallback'
+      }
+    }];
+
+    let request = spec.buildRequests(bidRequests);
+
+    it('should have a get method', () => {
+      expect(request.method).to.equal('GET');
+    });
+
+    it('should contains a request id equals to the bid id', () => {
+      expect(request.data.request_id).to.equal(bidRequests[0].bidId);
+    });
+
+    it('should have an url that contains bid keyword', () => {
+      expect(request.url).to.match(/bid/);
+    });
+
+    it('should create a callback function', () => {
+      expect(window[bidRequests[0].params.callbackName]).to.be.an('function');
+    });
+  });
+
+  describe('interpretResponse', () => {
+    let response = {
+      'request_id': '3db3773286ee59',
+      'cpm': 0.5,
+      'ad': '<!-- Creative -->',
+    };
+
+    it('should get correct bid response', () => {
+      let expectedResponse = [
+        {
+          requestId: '',
+          cpm: 0.5,
+          width: 1800,
+          height: 1000,
+          creativeId: 1,
+          dealId: 1,
+          currency: 'USD',
+          netRevenue: true,
+          ttl: 600,
+          referrer: '',
+          ad: '',
+        },
+      ];
+      let bidderRequest;
+      let result = spec.interpretResponse({body: response}, {bidderRequest});
+      expect(Object.keys(result[0]))
+        .to
+        .have
+        .members(Object.keys(expectedResponse[0]));
+    });
+  });
+
+  describe('getUserSyncs', () => {
+    it('should return an empty array', () => {
+      let syncs = spec.getUserSyncs();
+      expect(syncs).to.be.an('array').that.is.empty;
+    });
+  });
+});


### PR DESCRIPTION
## Goal

Have a debug adapter to provide to sublime clients.
We sent some debug pixels using `sublime.analytics.fire` new signature.

## How to test

If you never used this repo : 
```sh
# In your env
git clone git@github.com:SublimeSkinz/Prebid.js.git
```
If you're not up to date `npm install` in Prebid.js folder

To check coding style
```
gulp lint
```

To check our unit tests with Karma :
```
gulp test
```

To check coverage :
```
gulp test-coverage
```

In Emilbus : 
-  in `Emilbus/sac/resources/test-display/prebidjs/single.html` file : change sacHost `sac.ayads.co.local` to sacHost: `sac.ayads.co` (or juste comment sacHost to use default sacHost)
- visits http://sac.ayads.co.local/resources/test-display/prebidjs/single.html?pbjs_debug=true
- verify in Network the call to http://sac.ayads.co.local/resources/test-display/prebidjs/prebid.js 
- search `v=0.3` at the end of the file, where sublime adapter is minify you have to find our new version `0.3.2`

- if the version is not `0.3.2` (the version of this branch : you can find it at the beginning of `Prebid.js/modules/sublimeBidAdapter.js` file : `SUBLIME_VERSION`), you have to do this : 
- launch `gulp build --modules=sublimeBidAdapter` in `Prebid.js` folder
- copy paste `build/dist/prebid.js` content in `Emilbus/sac/resources/test-display/prebidjs/prebid.js`

- you could have an ad (refresh)

## Critical barometer

- :ok_hand: code safe, none or little impact on live applications

