### PR TITLE
Updated Sublime Bid Adapter to v0.5.0

### DIFF
--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -44,11 +44,14 @@ function setState(value) {
  */
 function sendEvent(eventName, isMandatoryPixel) {
   let shoudSendPixel = (isMandatoryPixel || state.debug);
+  let ts = Date.now();
   let eventObject = {
-    tse: Date.now(),
+    t: ts,
+    tse: ts,
     z: state.zoneId,
     e: eventName,
     src: 'pa',
+    puid: state.transactionId,
     trId: state.transactionId,
     ver: SUBLIME_VERSION,
   };
@@ -61,24 +64,6 @@ function sendEvent(eventName, isMandatoryPixel) {
   } else {
     log('Not sending pixel for event (use debug: true to send it): ' + eventName, eventObject);
   }
-}
-
-/**
- * Function sendPixel, use it to send pixel to antenna
- * @param {String} pixelName
- */
-function sendPixel(pixelName) {
-  let pixelObject = {
-    t: Date.now(),
-    z: state.zoneId,
-    e: pixelName,
-    et: Math.round(window.performance.now()),
-  };
-
-  log('Sending pixel: ' + pixelName, pixelObject);
-
-  let queryString = url.formatQS(pixelObject);
-  utils.triggerPixel('https://' + SUBLIME_ANTENNA + '/?' + queryString);
 }
 
 /**
@@ -248,11 +233,7 @@ function interpretResponse(serverResponse, bidRequest) {
       ad: response.ad,
     };
 
-    // Timing debug bid pixel
     sendEvent('bid', true);
-
-    // Count bid pixel
-    sendPixel('bid');
     bidResponses.push(bidResponse);
   } else {
     sendEvent('dnobid');

--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -130,7 +130,7 @@ function buildRequests(validBidRequests, bidderRequest) {
     // Register a callback to send notify
     window[callbackName] = (response) => {
       function querify(params) {
-        Object.keys(params).map(function (key) {
+        return Object.keys(params).map(function (key) {
           return key + '=' + encodeURIComponent(params[key])
         }).join('&')
       }

--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -1,135 +1,255 @@
 import { registerBidder } from '../src/adapters/bidderFactory';
 import { config } from '../src/config';
+import * as utils from '../src/utils';
+import * as url from '../src/url';
 
 const BIDDER_CODE = 'sublime';
 const DEFAULT_BID_HOST = 'pbjs.sskzlabs.com';
+const DEFAULT_CALLBACK_NAME = 'sublime_prebid_callback';
 const DEFAULT_CURRENCY = 'EUR';
 const DEFAULT_PROTOCOL = 'https';
+const DEFAULT_SAC_HOST = 'sac.ayads.co'
 const DEFAULT_TTL = 600;
-const SUBLIME_VERSION = '0.4.0';
+// TODO: Find the URL
+const SUBLIME_ANTENNA = 'antenna.co.local/debug';
+const SUBLIME_VERSION = '0.5.0';
+
+/**
+ * Debug log message
+ * @param {String} msg
+ * @param {Object} obj
+ */
+function log(msg, obj) {
+  utils.logInfo('SublimeBidAdapter - ' + msg, obj)
+}
+
+/**
+ * Sublime Bid Adapter state
+ * We use those information to send debug pixels
+ */
+const state = {
+  zoneId: '',
+  gdpr: {
+    consent: 0,
+    applies: 0,
+    source: false,
+  },
+  transactionId: ''
+};
+
+function setState(value) {
+  Object.assign(state, value)
+  log('State has been updated :', state)
+}
+
+/**
+ * Send pixel to our debug endpoint
+ * @param {string} eventName - Event name that will be send in the e= query string
+ */
+function sendEvent(eventName) {
+  let eventObject = {
+    tse: Date.now(),
+    z: state.zoneId,
+    gm: state.gdpr.consent,
+    ga: state.gdpr.applies,
+    gs: state.gdpr.source,
+    e: eventName,
+    src: 'pa',
+    trId: state.transactionId,
+    ver: SUBLIME_VERSION,
+  };
+
+  let queryString = url.formatQS(eventObject);
+
+  log('Sending pixel for event: ' + eventName, eventObject);
+  utils.triggerPixel('https://' + SUBLIME_ANTENNA + '/?' + queryString);
+}
+
+/**
+ * Determines whether or not the given bid request is valid.
+ *
+ * @param {BidRequest} bid The bid params to validate.
+ * @return {Boolean} True if this is a valid bid, and false otherwise.
+ */
+function isBidRequestValid(bid) {
+  return !!bid.params.zoneId;
+}
+
+/**
+ * Make a server request from the list of BidRequests.
+ *
+ * @param {BidRequest[]} validBidRequests An array of bids
+ * @param {Object} bidderRequest - Info describing the request to the server.
+ * @return ServerRequest Info describing the request to the server.
+ */
+function buildRequests(validBidRequests, bidderRequest) {
+  window.sublime = window.sublime ? window.sublime : {};
+
+  let commonPayload = {
+    sublimeVersion: SUBLIME_VERSION,
+    // Current Prebid params
+    prebidVersion: '$prebid.version$',
+    currencyCode: config.getConfig('currency.adServerCurrency') || DEFAULT_CURRENCY,
+    timeout: typeof bidderRequest !== 'undefined' ? bidderRequest.timeout : config.getConfig('bidderTimeout'),
+  };
+
+  // RefererInfo
+  if (bidderRequest && bidderRequest.refererInfo) {
+    commonPayload.referer = bidderRequest.refererInfo.referer;
+    commonPayload.numIframes = bidderRequest.refererInfo.numIframes;
+  }
+  // GDPR handling
+  if (bidderRequest && bidderRequest.gdprConsent) {
+    commonPayload.gdprConsent = bidderRequest.gdprConsent.consentString;
+    commonPayload.gdpr = bidderRequest.gdprConsent.gdprApplies; // we're handling the undefined case server side
+
+    setState({
+      gdpr: {
+        consent: bidderRequest.gdprConsent.consentString ? 1 : 0,
+        applies: bidderRequest.gdprConsent.gdprApplies ? 1 : 0,
+        source: bidderRequest.gdprConsent.consentString ? 'cmp' : '',
+      }
+    });
+
+    // Injecting gdpr consent into sublime tag
+    window.sublime.gdpr = (typeof window.sublime.gdpr !== 'undefined') ? window.sublime.gdpr : {};
+    window.sublime.gdpr.injected = {
+      consentString: bidderRequest.gdprConsent.consentString,
+      gdprApplies: bidderRequest.gdprConsent.gdprApplies
+    };
+  }
+
+  return validBidRequests.map(bid => {
+    let bidHost = bid.params.bidHost || DEFAULT_BID_HOST;
+    let callbackName = (bid.params.callbackName || DEFAULT_CALLBACK_NAME) + '_' + bid.params.zoneId;
+    let protocol = bid.params.protocol || DEFAULT_PROTOCOL;
+    let sacHost = bid.params.sacHost || DEFAULT_SAC_HOST;
+
+    setState({ transactionId: bid.transactionId, zoneId: bid.params.zoneId });
+
+    // Adding Sublime tag
+    let script = document.createElement('script');
+    script.type = 'application/javascript';
+    script.src = 'https://' + sacHost + '/sublime/' + bid.params.zoneId + '/prebid?callback=' + callbackName;
+    document.body.appendChild(script);
+
+    // Register a callback to send notify
+    window[callbackName] = (response) => {
+      var hasAd = response.ad ? '1' : '0';
+      var xhr = new XMLHttpRequest();
+      var url = protocol + '://' + bidHost + '/notify';
+      var params = {
+        a: hasAd,
+        ad: response.ad || '',
+        cpm: response.cpm || 0,
+        currency: response.currency || 'USD',
+        notify: 1,
+        requestId: bid.bidId ? encodeURIComponent(bid.bidId) : null,
+        transactionId: bid.transactionId,
+        zoneId: bid.params.zoneId
+      };
+
+      xhr.open('POST', url + '?' +
+        Object.keys(params).map(function (key) {
+          return key + '=' + encodeURIComponent(params[key])
+        }).join('&'), true);
+      xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+      xhr.send();
+      return xhr;
+    };
+
+    let bidPayload = {
+      adUnitCode: bid.adUnitCode,
+      auctionId: bid.auctionId,
+      bidder: bid.bidder,
+      bidderRequestId: bid.bidderRequestId,
+      bidRequestsCount: bid.bidRequestsCount,
+      requestId: bid.bidId,
+      sizes: bid.sizes.map(size => ({
+        w: size[0],
+        h: size[1],
+      })),
+      transactionId: bid.transactionId,
+      zoneId: bid.params.zoneId,
+    };
+
+    let payload = Object.assign({}, commonPayload, bidPayload);
+
+    return {
+      method: 'POST',
+      url: protocol + '://' + bidHost + '/bid',
+      data: payload,
+      options: {
+        contentType: 'application/json',
+        withCredentials: true
+      },
+    };
+  });
+}
+
+/**
+ * Unpack the response from the server into a list of bids.
+ *
+ * @param {*} serverResponse A successful response from the server.
+ * @param {*} bidRequest An object with bid request informations
+ * @return {Bid[]} An array of bids which were nested inside the server.
+ */
+function interpretResponse(serverResponse, bidRequest) {
+  const bidResponses = [];
+  const response = serverResponse.body;
+
+  if (response) {
+    if (response.timeout || !response.ad || response.ad.match(/<!-- No ad -->/gmi)) {
+      return bidResponses;
+    }
+
+    // Setting our returned sizes object to default values
+    let returnedSizes = {
+      width: 1800,
+      height: 1000
+    };
+
+    // Verifying Banner sizes
+    if (bidRequest && bidRequest.data && bidRequest.data.w === 1 && bidRequest.data.h === 1) {
+      // If banner sizes are 1x1 we set our default size object to 1x1
+      returnedSizes = {
+        width: 1,
+        height: 1
+      };
+    }
+
+    const bidResponse = {
+      requestId: response.requestId || '',
+      cpm: response.cpm || 0,
+      width: response.width || returnedSizes.width,
+      height: response.height || returnedSizes.height,
+      creativeId: response.creativeId || 1,
+      dealId: response.dealId || 1,
+      currency: response.currency || DEFAULT_CURRENCY,
+      netRevenue: response.netRevenue || true,
+      ttl: response.ttl || DEFAULT_TTL,
+      ad: response.ad,
+    };
+
+    sendEvent('bid');
+    bidResponses.push(bidResponse);
+  }
+
+  return bidResponses;
+}
+
+function onTimeout(timeoutData) {
+  log('Timeout from adapter', timeoutData);
+  sendEvent('dbidtimeout');
+}
 
 export const spec = {
   code: BIDDER_CODE,
   aliases: [],
-
-  /**
-     * Determines whether or not the given bid request is valid.
-     *
-     * @param {BidRequest} bid The bid params to validate.
-     * @return boolean True if this is a valid bid, and false otherwise.
-     */
-  isBidRequestValid: (bid) => {
-    return !!bid.params.zoneId;
-  },
-
-  /**
-     * Make a server request from the list of BidRequests.
-     *
-     * @param {BidRequest[]} validBidRequests An array of bids
-     * @param {Object} bidderRequest - Info describing the request to the server.
-     * @return ServerRequest Info describing the request to the server.
-     */
-  buildRequests: (validBidRequests, bidderRequest) => {
-    let commonPayload = {
-      sublimeVersion: SUBLIME_VERSION,
-      // Current Prebid params
-      prebidVersion: '$prebid.version$',
-      currencyCode: config.getConfig('currency.adServerCurrency') || DEFAULT_CURRENCY,
-      timeout: config.getConfig('bidderTimeout'),
-    };
-
-    // RefererInfo
-    if (bidderRequest && bidderRequest.refererInfo) {
-      commonPayload.referer = bidderRequest.refererInfo.referer;
-      commonPayload.numIframes = bidderRequest.refererInfo.numIframes;
-    }
-    // GDPR handling
-    if (bidderRequest && bidderRequest.gdprConsent) {
-      commonPayload.gdprConsent = bidderRequest.gdprConsent.consentString;
-      commonPayload.gdpr = bidderRequest.gdprConsent.gdprApplies; // we're handling the undefined case server side
-    }
-
-    return validBidRequests.map(bid => {
-      let bidPayload = {
-        adUnitCode: bid.adUnitCode,
-        auctionId: bid.auctionId,
-        bidder: bid.bidder,
-        bidderRequestId: bid.bidderRequestId,
-        bidRequestsCount: bid.bidRequestsCount,
-        requestId: bid.bidId,
-        sizes: bid.sizes.map(size => ({
-          w: size[0],
-          h: size[1],
-        })),
-        transactionId: bid.transactionId,
-        zoneId: bid.params.zoneId,
-      };
-
-      let protocol = bid.params.protocol || DEFAULT_PROTOCOL;
-      let bidHost = bid.params.bidHost || DEFAULT_BID_HOST;
-      let payload = Object.assign({}, commonPayload, bidPayload);
-
-      return {
-        method: 'POST',
-        url: protocol + '://' + bidHost + '/bid',
-        data: payload,
-        options: {
-          contentType: 'application/json',
-          withCredentials: true
-        },
-      };
-    });
-  },
-
-  /**
-     * Unpack the response from the server into a list of bids.
-     *
-     * @param {*} serverResponse A successful response from the server.
-     * @param {*} bidRequest An object with bid request informations
-     * @return {Bid[]} An array of bids which were nested inside the server.
-     */
-  interpretResponse: (serverResponse, bidRequest) => {
-    const bidResponses = [];
-    const response = serverResponse.body;
-
-    if (response) {
-      if (response.timeout || !response.ad || response.ad.match(/<!-- No ad -->/gmi)) {
-        return bidResponses;
-      }
-
-      // Setting our returned sizes object to default values
-      let returnedSizes = {
-        width: 1800,
-        height: 1000
-      };
-
-      // Verifying Banner sizes
-      if (bidRequest && bidRequest.data && bidRequest.data.w === 1 && bidRequest.data.h === 1) {
-        // If banner sizes are 1x1 we set our default size object to 1x1
-        returnedSizes = {
-          width: 1,
-          height: 1
-        };
-      }
-
-      const bidResponse = {
-        requestId: response.requestId || '',
-        cpm: response.cpm || 0,
-        width: response.width || returnedSizes.width,
-        height: response.height || returnedSizes.height,
-        creativeId: response.creativeId || 1,
-        dealId: response.dealId || 1,
-        currency: response.currency || DEFAULT_CURRENCY,
-        netRevenue: response.netRevenue || true,
-        ttl: response.ttl || DEFAULT_TTL,
-        ad: response.ad,
-      };
-
-      bidResponses.push(bidResponse);
-    }
-
-    return bidResponses;
-  },
+  isBidRequestValid: isBidRequestValid,
+  buildRequests: buildRequests,
+  interpretResponse: interpretResponse,
+  onTimeout: onTimeout,
 };
 
 registerBidder(spec);

--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -64,6 +64,24 @@ function sendEvent(eventName, isMandatoryPixel) {
 }
 
 /**
+ * Function sendPixel, use it to send pixel to antenna
+ * @param {String} pixelName
+ */
+function sendPixel(pixelName) {
+  let pixelObject = {
+    t: Date.now(),
+    z: state.zoneId,
+    e: pixelName,
+    et: Math.round(window.performance.now()),
+  };
+
+  log('Sending pixel: ' + pixelName, pixelObject);
+
+  let queryString = url.formatQS(pixelObject);
+  utils.triggerPixel('https://' + SUBLIME_ANTENNA + '/?' + queryString);
+}
+
+/**
  * Determines whether or not the given bid request is valid.
  *
  * @param {BidRequest} bid The bid params to validate.
@@ -230,7 +248,11 @@ function interpretResponse(serverResponse, bidRequest) {
       ad: response.ad,
     };
 
+    // Timing debug bid pixel
     sendEvent('bid', true);
+
+    // Count bid pixel
+    sendPixel('bid');
     bidResponses.push(bidResponse);
   } else {
     sendEvent('dnobid');
@@ -245,7 +267,7 @@ function interpretResponse(serverResponse, bidRequest) {
  */
 function onTimeout(timeoutData) {
   log('Timeout from adapter', timeoutData);
-  sendEvent('dbidtimeout');
+  sendEvent('dbidtimeout', true);
 }
 
 export const spec = {

--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -113,7 +113,7 @@ function buildRequests(validBidRequests, bidderRequest) {
     setState({
       transactionId: bid.transactionId,
       zoneId: bid.params.zoneId,
-      debug: params.debug || false,
+      debug: bid.params.debug || false,
     });
 
     // Adding Sublime tag

--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -53,9 +53,12 @@ function sendEvent(eventName, isMendatoryPixel) {
   };
 
   let queryString = url.formatQS(eventObject);
-
-  log('Sending pixel for event: ' + eventName, eventObject);
-  shoudNotSendPixel || utils.triggerPixel('https://' + SUBLIME_ANTENNA + '/?' + queryString);
+  if (shoudNotSendPixel) {
+    log('Not sending pixel for event (use debug: true to send it): ' + eventName, eventObject);
+  } else {
+    log('Sending pixel for event: ' + eventName, eventObject);
+    utils.triggerPixel('https://' + SUBLIME_ANTENNA + '/?' + queryString);
+  }
 }
 
 /**

--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -10,8 +10,7 @@ const DEFAULT_CURRENCY = 'EUR';
 const DEFAULT_PROTOCOL = 'https';
 const DEFAULT_SAC_HOST = 'sac.ayads.co'
 const DEFAULT_TTL = 600;
-// TODO: Find the URL
-const SUBLIME_ANTENNA = 'antenna.co.local/debug';
+const SUBLIME_ANTENNA = 'antenna.ayads.co';
 const SUBLIME_VERSION = '0.5.0';
 
 /**
@@ -23,10 +22,7 @@ function log(msg, obj) {
   utils.logInfo('SublimeBidAdapter - ' + msg, obj)
 }
 
-/**
- * Sublime Bid Adapter state
- * We use those information to send debug pixels
- */
+// Default state
 const state = {
   zoneId: '',
   gdpr: {
@@ -37,6 +33,10 @@ const state = {
   transactionId: ''
 };
 
+/**
+ * Set a new state
+ * @param {Object} value
+ */
 function setState(value) {
   Object.assign(state, value)
   log('State has been updated :', state)
@@ -137,7 +137,6 @@ function buildRequests(validBidRequests, bidderRequest) {
     window[callbackName] = (response) => {
       var hasAd = response.ad ? '1' : '0';
       var xhr = new XMLHttpRequest();
-      var url = protocol + '://' + bidHost + '/notify';
       var params = {
         a: hasAd,
         ad: response.ad || '',
@@ -148,11 +147,12 @@ function buildRequests(validBidRequests, bidderRequest) {
         transactionId: bid.transactionId,
         zoneId: bid.params.zoneId
       };
+      var queryString = Object.keys(params).map(function (key) {
+        return key + '=' + encodeURIComponent(params[key])
+      }).join('&');
+      var url = protocol + '://' + bidHost + '/notify?' + queryString;
 
-      xhr.open('POST', url + '?' +
-        Object.keys(params).map(function (key) {
-          return key + '=' + encodeURIComponent(params[key])
-        }).join('&'), true);
+      xhr.open('POST', url, true);
       xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
       xhr.send();
       return xhr;
@@ -238,6 +238,10 @@ function interpretResponse(serverResponse, bidRequest) {
   return bidResponses;
 }
 
+/**
+ * Send debug when we timeout
+ * @param {Object} timeoutData
+ */
 function onTimeout(timeoutData) {
   log('Timeout from adapter', timeoutData);
   sendEvent('dbidtimeout');

--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -41,7 +41,8 @@ function setState(value) {
  * Send pixel to our debug endpoint
  * @param {string} eventName - Event name that will be send in the e= query string
  */
-function sendEvent(eventName) {
+function sendEvent(eventName, isMendatoryPixel) {
+  let shoudNotSendPixel = !(isMendatoryPixel || state.debug);
   let eventObject = {
     tse: Date.now(),
     z: state.zoneId,
@@ -54,7 +55,7 @@ function sendEvent(eventName) {
   let queryString = url.formatQS(eventObject);
 
   log('Sending pixel for event: ' + eventName, eventObject);
-  utils.triggerPixel('https://' + SUBLIME_ANTENNA + '/?' + queryString);
+  shoudNotSendPixel || utils.triggerPixel('https://' + SUBLIME_ANTENNA + '/?' + queryString);
 }
 
 /**
@@ -109,7 +110,11 @@ function buildRequests(validBidRequests, bidderRequest) {
     let protocol = bid.params.protocol || DEFAULT_PROTOCOL;
     let sacHost = bid.params.sacHost || DEFAULT_SAC_HOST;
 
-    setState({ transactionId: bid.transactionId, zoneId: bid.params.zoneId });
+    setState({
+      transactionId: bid.transactionId,
+      zoneId: bid.params.zoneId,
+      debug: params.debug || false,
+    });
 
     // Adding Sublime tag
     let script = document.createElement('script');
@@ -217,7 +222,7 @@ function interpretResponse(serverResponse, bidRequest) {
       ad: response.ad,
     };
 
-    sendEvent('bid');
+    sendEvent('bid', true);
     bidResponses.push(bidResponse);
   } else {
     sendEvent('dnobid');

--- a/test/spec/modules/sublimeBidAdapter_spec.js
+++ b/test/spec/modules/sublimeBidAdapter_spec.js
@@ -70,17 +70,14 @@ describe('Sublime Adapter', function() {
 
     it('should have a post method', function() {
       expect(request[0].method).to.equal('POST');
-      expect(request[1].method).to.equal('POST');
     });
 
     it('should contains a request id equals to the bid id', function() {
       expect(request[0].data.requestId).to.equal(bidRequests[0].bidId);
-      expect(request[1].data.requestId).to.equal(bidRequests[1].bidId);
     });
 
     it('should have an url that contains bid keyword', function() {
       expect(request[0].url).to.match(/bid/);
-      expect(request[1].url).to.match(/bid/);
     });
   });
 


### PR DESCRIPTION
## Type of change
 - New bidder adapter
## Description of change
Added new Adapter for Sublime

- code: modules/sublimeBidAdapter.js

- doc: modules/sublimeBidAdapter.md

- unit test: test/spec/modules/sublimeBidAdapter_spec.js

- test parameters for validating bids

```
{
  bidder: 'sublime',
  params: {
    zoneId: 16007
  }
}
```
Be sure to test the integration with your adserver using the Hello World sample page.

- contact email of the adapter’s maintainer: pbjs@sublime.xyz

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/