### PR TITLE
DL-1475: handle notify

### DIFF
--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -48,8 +48,8 @@ export function sendEvent(eventName) {
     z: state.zoneId,
     e: eventName,
     src: 'pa',
-    puid: state.transactionId,
-    trId: state.transactionId,
+    puid: state.transactionId || state.notifyId,
+    trId: state.transactionId || state.notifyId,
     ver: SUBLIME_VERSION,
   };
 

--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -9,7 +9,7 @@ const DEFAULT_CURRENCY = 'EUR';
 const DEFAULT_PROTOCOL = 'https';
 const DEFAULT_TTL = 600;
 const SUBLIME_ANTENNA = 'antenna.ayads.co';
-const SUBLIME_VERSION = '0.5.2';
+const SUBLIME_VERSION = '0.6.0';
 
 /**
  * Debug log message
@@ -23,7 +23,8 @@ export function log(msg, obj) {
 // Default state
 export const state = {
   zoneId: '',
-  transactionId: ''
+  transactionId: '',
+  notifyId: ''
 };
 
 /**
@@ -101,6 +102,7 @@ function buildRequests(validBidRequests, bidderRequest) {
 
     setState({
       transactionId: bid.transactionId,
+      notifyId: bid.params.notifyId,
       zoneId: bid.params.zoneId,
       debug: bid.params.debug || false,
     });
@@ -117,6 +119,7 @@ function buildRequests(validBidRequests, bidderRequest) {
         h: size[1],
       })),
       transactionId: bid.transactionId,
+      notifyId: bid.params.notifyId,
       zoneId: bid.params.zoneId,
     };
 

--- a/modules/sublimeBidAdapter.md
+++ b/modules/sublimeBidAdapter.md
@@ -62,4 +62,4 @@ var adUnits = [{
 
 Where you replace:
 - `<zoneId>` by your Sublime Zone id;
-- `<notifyId>` by a random Id
+- `<notifyId>` by your Sublime Notify id

--- a/modules/sublimeBidAdapter.md
+++ b/modules/sublimeBidAdapter.md
@@ -9,7 +9,7 @@ Maintainer: pbjs@sublimeskinz.com
 # Description
 
 Connects to Sublime for bids.
-Sublime bid adapter supports Skinz and M-Skinz formats.
+Sublime bid adapter supports Skinz.
 
 # Nota Bene
 
@@ -53,10 +53,13 @@ var adUnits = [{
     bids: [{
         bidder: 'sublime',
         params: {
-            zoneId: <zoneId>
+            zoneId: <zoneId>,
+            notifyId: <notifyId>
         }
     }]
 }];
 ```
 
-Where you replace `<zoneId>` by your Sublime Zone id
+Where you replace:
+- `<zoneId>` by your Sublime Zone id;
+- `<notifyId>` by a random Id

--- a/test/spec/modules/sublimeBidAdapter_spec.js
+++ b/test/spec/modules/sublimeBidAdapter_spec.js
@@ -149,7 +149,7 @@ describe('Sublime Adapter', function() {
           currency: 'USD',
           netRevenue: true,
           ttl: 600,
-          pbav: '0.5.2',
+          pbav: '0.6.0',
           ad: '',
         },
       ];
@@ -191,7 +191,7 @@ describe('Sublime Adapter', function() {
         netRevenue: true,
         ttl: 600,
         ad: '<!-- Creative -->',
-        pbav: '0.5.2',
+        pbav: '0.6.0',
       };
 
       expect(result[0]).to.deep.equal(expectedResponse);
@@ -241,7 +241,7 @@ describe('Sublime Adapter', function() {
         netRevenue: true,
         ttl: 600,
         ad: '<!-- ad -->',
-        pbav: '0.5.2',
+        pbav: '0.6.0',
       };
 
       expect(result[0]).to.deep.equal(expectedResponse);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
- using the notifyId param;

## How to test

- check that `gulp test' are not red for the sublimeAdapter.js module;
- modify the "integrationExamples/gpt/hello_world.html" file:

    - add the sjs script in the head:

    ```html
    <script src="http://sac.ayads.co.local/sublime/29433/prebid"></script>
    ```

    - modify the adUnits:

    ```javascript
    {
      bidder: 'sublime',
      params: {
        zoneId: 29433,
        notifyId: (function b(a){return a?(a^Math.random()*16>>a/4).toString(16):([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g,b)})()
      }
    }
    ```

- execute:

```bash
gulp serve-fast --modules=appnexusBidAdapter,sublimeBidAdapter`
```

This will compile prebid.js including the two adapters, launch a test server and run the tests.
- open then http://localhost:9999/integrationExamples/gpt/hello_world.html
- check that the notifyId param is sent in the /bid POST request;


https://sublimeskinz.atlassian.net/browse/DL-1475