### PR TITLE
DL-1590: Update bidwon and bidtimeout pixels

### DIFF
--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -9,7 +9,23 @@ const DEFAULT_CURRENCY = 'EUR';
 const DEFAULT_PROTOCOL = 'https';
 const DEFAULT_TTL = 600;
 const SUBLIME_ANTENNA = 'antenna.ayads.co';
-const SUBLIME_VERSION = '0.7.0';
+const SUBLIME_VERSION = '0.7.1';
+
+/**
+ * Identify the current device type
+ * @returns {string}
+ */
+function detectDevice() {
+  const isMobile = /(?:phone|windowss+phone|ipod|blackberry|Galaxy Nexus|SM-G892A|(?:android|bbd+|meego|silk|googlebot) .+?mobile|palm|windowss+ce|opera mini|avantgo|docomo)/i;
+
+  const isTablet = /(?:ipad|playbook|Tablet|(?:android|bb\\d+|meego|silk)(?! .+? mobile))/i;
+
+  return (
+    (isMobile.test(navigator.userAgent) && 'm') || // mobile
+    (isTablet.test(navigator.userAgent) && 't') || // tablet
+    'd' // desktop
+  );
+}
 
 /**
  * Debug log message
@@ -39,8 +55,9 @@ export function setState(value) {
 /**
  * Send pixel to our debug endpoint
  * @param {string} eventName - Event name that will be send in the e= query string
+ * @param {string} [sspName] - The optionnal name of the AD provider
  */
-export function sendEvent(eventName) {
+export function sendEvent(eventName, sspName) {
   const ts = Date.now();
   const eventObject = {
     t: ts,
@@ -51,7 +68,14 @@ export function sendEvent(eventName) {
     puid: state.transactionId || state.notifyId,
     trId: state.transactionId || state.notifyId,
     pbav: SUBLIME_VERSION,
+    timeout: config.getConfig('bidderTimeout'),
+    ver: '$prebid.version$',
+    device: detectDevice(),
   };
+
+  if (eventName === 'bidwon') {
+    eventObject.sspname = sspName || ''
+  }
 
   log('Sending pixel for event: ' + eventName, eventObject);
 
@@ -179,7 +203,8 @@ function interpretResponse(serverResponse, bidRequest) {
       netRevenue: response.netRevenue || true,
       ttl: response.ttl || DEFAULT_TTL,
       ad: response.ad,
-      pbav: SUBLIME_VERSION
+      pbav: SUBLIME_VERSION,
+      sspname: response.sspname || null
     };
 
     bidResponses.push(bidResponse);
@@ -194,7 +219,7 @@ function interpretResponse(serverResponse, bidRequest) {
  */
 function onBidWon(bid) {
   log('Bid won', bid);
-  sendEvent('bidwon');
+  sendEvent('bidwon', bid.sspname);
 }
 
 /**

--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -68,13 +68,13 @@ export function sendEvent(eventName, sspName) {
     puid: state.transactionId || state.notifyId,
     trId: state.transactionId || state.notifyId,
     pbav: SUBLIME_VERSION,
-    timeout: config.getConfig('bidderTimeout'),
-    ver: '$prebid.version$',
+    pubtimeout: config.getConfig('bidderTimeout'),
+    pubpbv: '$prebid.version$',
     device: detectDevice(),
   };
 
   if (eventName === 'bidwon') {
-    eventObject.sspname = sspName || ''
+    eventObject.sspname = sspName || '';
   }
 
   log('Sending pixel for event: ' + eventName, eventObject);

--- a/test/spec/modules/sublimeBidAdapter_spec.js
+++ b/test/spec/modules/sublimeBidAdapter_spec.js
@@ -18,9 +18,9 @@ describe('Sublime Adapter', function() {
       'puid',
       'trId',
       'pbav',
-      'ver',
+      'pubpbv',
       'device',
-      'timeout',
+      'pubtimeout',
     ];
 
     beforeEach(function () {

--- a/test/spec/modules/sublimeBidAdapter_spec.js
+++ b/test/spec/modules/sublimeBidAdapter_spec.js
@@ -18,6 +18,9 @@ describe('Sublime Adapter', function() {
       'puid',
       'trId',
       'pbav',
+      'ver',
+      'device',
+      'timeout',
     ];
 
     beforeEach(function () {
@@ -139,6 +142,7 @@ describe('Sublime Adapter', function() {
   describe('interpretResponse', function() {
     let serverResponse = {
       'request_id': '3db3773286ee59',
+      'sspname': 'foo',
       'cpm': 0.5,
       'ad': '<!-- Creative -->',
     };
@@ -160,9 +164,10 @@ describe('Sublime Adapter', function() {
           creativeId: 1,
           dealId: 1,
           currency: 'USD',
+          sspname: 'foo',
           netRevenue: true,
           ttl: 600,
-          pbav: '0.7.0',
+          pbav: '0.7.1',
           ad: '',
         },
       ];
@@ -173,6 +178,7 @@ describe('Sublime Adapter', function() {
     it('should get correct default size for 1x1', function() {
       let serverResponse = {
         'requestId': 'xyz654_2',
+        'sspname': 'sublime',
         'cpm': 0.5,
         'ad': '<!-- Creative -->',
       };
@@ -204,7 +210,8 @@ describe('Sublime Adapter', function() {
         netRevenue: true,
         ttl: 600,
         ad: '<!-- Creative -->',
-        pbav: '0.7.0',
+        pbav: '0.7.1',
+        sspname: 'sublime'
       };
 
       expect(result[0]).to.deep.equal(expectedResponse);
@@ -224,6 +231,7 @@ describe('Sublime Adapter', function() {
     it('should return bid with default value in response', function () {
       let serverResponse = {
         'requestId': 'xyz654_2',
+        'sspname': 'sublime',
         'ad': '<!-- ad -->',
       };
 
@@ -251,10 +259,11 @@ describe('Sublime Adapter', function() {
         creativeId: 1,
         dealId: 1,
         currency: 'EUR',
+        sspname: 'sublime',
         netRevenue: true,
         ttl: 600,
         ad: '<!-- ad -->',
-        pbav: '0.7.0',
+        pbav: '0.7.1',
       };
 
       expect(result[0]).to.deep.equal(expectedResponse);


### PR DESCRIPTION
## Description of change
Update sublimeAdapter to version 0.7.1: We need more data in the pixels we send to better qualified our win.

## How to test
See : https://github.com/SublimeSkinz/Emilbus/pull/3086 to understand how to use sskz_publishers to test the prebid.js build

Each time we win a bid, checkout the `bidwon` pixels, it should have some new data: `device`, `ver` and `timeout`
The same data should be send in case of a `bidtimeout`

## JIRA Ticket
https://sublimeskinz.atlassian.net/browse/DL-1590
