### PR TITLE
DL-1746: Remove trId and use notid instead

### DIFF
--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -66,7 +66,7 @@ export function sendEvent(eventName, sspName) {
     e: eventName,
     src: 'pa',
     puid: state.transactionId || state.notifyId,
-    notid: state.notifyId,
+    notid: state.notifyId || '',
     pbav: SUBLIME_VERSION,
     pubtimeout: config.getConfig('bidderTimeout'),
     pubpbv: '$prebid.version$',

--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -9,7 +9,7 @@ const DEFAULT_CURRENCY = 'EUR';
 const DEFAULT_PROTOCOL = 'https';
 const DEFAULT_TTL = 600;
 const SUBLIME_ANTENNA = 'antenna.ayads.co';
-const SUBLIME_VERSION = '0.7.2';
+const SUBLIME_VERSION = '0.7.3';
 
 /**
  * Identify the current device type

--- a/modules/sublimeBidAdapter.js
+++ b/modules/sublimeBidAdapter.js
@@ -66,7 +66,7 @@ export function sendEvent(eventName, sspName) {
     e: eventName,
     src: 'pa',
     puid: state.transactionId || state.notifyId,
-    trId: state.transactionId || state.notifyId,
+    notid: state.notifyId,
     pbav: SUBLIME_VERSION,
     pubtimeout: config.getConfig('bidderTimeout'),
     pubpbv: '$prebid.version$',

--- a/test/spec/modules/sublimeBidAdapter_spec.js
+++ b/test/spec/modules/sublimeBidAdapter_spec.js
@@ -167,7 +167,7 @@ describe('Sublime Adapter', function() {
           sspname: 'foo',
           netRevenue: true,
           ttl: 600,
-          pbav: '0.7.2',
+          pbav: '0.7.3',
           ad: '',
         },
       ];
@@ -210,7 +210,7 @@ describe('Sublime Adapter', function() {
         netRevenue: true,
         ttl: 600,
         ad: '<!-- Creative -->',
-        pbav: '0.7.2',
+        pbav: '0.7.3',
         sspname: 'sublime'
       };
 
@@ -263,7 +263,7 @@ describe('Sublime Adapter', function() {
         netRevenue: true,
         ttl: 600,
         ad: '<!-- ad -->',
-        pbav: '0.7.2',
+        pbav: '0.7.3',
       };
 
       expect(result[0]).to.deep.equal(expectedResponse);

--- a/test/spec/modules/sublimeBidAdapter_spec.js
+++ b/test/spec/modules/sublimeBidAdapter_spec.js
@@ -16,7 +16,7 @@ describe('Sublime Adapter', function() {
       'e',
       'src',
       'puid',
-      'trId',
+      'notid',
       'pbav',
       'pubpbv',
       'device',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
